### PR TITLE
 Map TAG= to bootstrap phase info

### DIFF
--- a/usr/lib/python3/dist-packages/anon_connection_wizard/anon_connection_wizard.py
+++ b/usr/lib/python3/dist-packages/anon_connection_wizard/anon_connection_wizard.py
@@ -1605,6 +1605,11 @@ class TorBootstrap(QtCore.QThread):
 
     def run(self):
         self.tor_controller = self.connect_to_control_port()
+        '''if DisableNetwork is 1, then toggle it to 0
+        because we really want Tor connect to the network'''
+        if self.tor_controller.get_conf('DisableNetwork') is '1':
+            self.tor_controller.set_conf('DisableNetwork', '0')
+
         bootstrap_percent = 0
         while bootstrap_percent < 100:
             bootstrap_status = self.tor_controller.get_info("status/bootstrap-phase")

--- a/usr/lib/python3/dist-packages/anon_connection_wizard/tor_status.py
+++ b/usr/lib/python3/dist-packages/anon_connection_wizard/tor_status.py
@@ -77,6 +77,10 @@ def set_enabled():
     if tor_status_code != 0:
         return 'cannot_connect', tor_status_code
 
+    ## we have to reload to open /var/run/tor/control and create /var/run/tor/control.authcookie
+    command = 'systemctl reload tor@default.service'
+    tor_status_code = call(command, shell=True)
+
     command = 'systemctl --no-pager status tor@default'
     tor_status_code= call(command, shell=True)
 


### PR DESCRIPTION
This implementation will prepare the bootstrap phase info for being translated.

It will also mitigate the vulnerability described in: http://forums.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/t/graphical-gui-whonix-setup-wizard-anon-connection-wizard-technical-discussion/650/540

However, I choose not to prevent the weird `SUMMARY=` from showing up when an attacker manipulates both `TAG=` and `SUMMARY=`. Because:

1. The implementation will be consistent with the Tor launcher [doc](https://gitweb.torproject.org/tor-launcher.git/plain/README-BOOTSTRAP):
>If Tor Launcher cannot map the TAG to a localized string, it displays the SUMMARY text instead otherwise, the SUMMARY field is not used).
2. When such an attack is performed, we need to stay alert of it somehow.

What I am wondering is if such an alert should be exposed to daily user. Or should we simply keep it in a log?